### PR TITLE
Ignition patch

### DIFF
--- a/extra-patches/ignition.patch
+++ b/extra-patches/ignition.patch
@@ -1,0 +1,12 @@
+diff --git a/dracut/30ignition/module-setup.sh b/dracut/30ignition/module-setup.sh
+index 86f24721..df599e8c 100755
+--- a/dracut/30ignition/module-setup.sh
++++ b/dracut/30ignition/module-setup.sh
+@@ -130,6 +130,6 @@ installkernel() {
+ 
+     # required by nvidiabluefield platform to read ignition file through bootfifo sysfs interface
+     if [[ ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]]; then
+-        instmods -c mlxbf_bootctl
++        instmods mlxbf_bootctl
+     fi
+ }

--- a/extra-patches/series
+++ b/extra-patches/series
@@ -2,3 +2,4 @@ gomodsum.patch
 selinux.patch
 uuid.patch
 url.patch
+ignition.patch


### PR DESCRIPTION
**What this PR does / why we need it**:
Including the _mlxbf_bootctl_ kernel module should be optional.

**Which issue(s) this PR fixes**:
Fixes #
